### PR TITLE
Missing authroles in wamp context for oauth2 flow

### DIFF
--- a/apps/bondy/src/bondy_dealer.erl
+++ b/apps/bondy/src/bondy_dealer.erl
@@ -1516,7 +1516,7 @@ handle_call(Msg, ProcUri, Fun, Opts, Ctxt) when is_function(Fun, 2) ->
         {ok, Entry} ->
             do_call(CallId, ProcUri, Fun, Opts, Ctxt, Entry);
 
-        {error, no_proc} ->
+        {error, noproc} ->
             %% The matches were all dead (local process dead or remote target
             %% unreachable)
             Error = case format_error(no_such_procedure, Opts) of
@@ -1634,10 +1634,10 @@ do_call(CallId, ProcUri, UserFun, Opts, Ctxt0, Entry) ->
 %% -----------------------------------------------------------------------------
 -spec choose(
     Entries :: {[entry()], trie_continuation() | eot()} | eot(),
-    CallOpts :: map()) -> {ok, Entry :: entry()} | {error, no_proc}.
+    CallOpts :: map()) -> {ok, Entry :: entry()} | {error, noproc}.
 
 choose(?EOT, _) ->
-    {error, no_proc};
+    {error, noproc};
 
 choose({L, Cont}, CallOpts) ->
     choose(L, CallOpts, undefined, [], Cont).
@@ -1653,10 +1653,10 @@ choose({L, Cont}, CallOpts) ->
     Group :: {Uri :: uri(), Match :: binary(), Invoke :: binary()} | undefined,
     Acc :: [entry()],
     Cont :: trie_continuation()) ->
-    {ok, Entry :: entry()} | {error, no_proc | any()}.
+    {ok, Entry :: entry()} | {error, noproc | any()}.
 
 choose([], _, _, [], ?EOT) ->
-    {error, no_proc};
+    {error, noproc};
 
 choose([], CallOpts, _, [], Cont) ->
     choose(bondy_registry:match(Cont), CallOpts);
@@ -1668,7 +1668,7 @@ choose([], CallOpts, {_, _, Invoke}, Acc, Cont) ->
     case bondy_rpc_load_balancer:select(L, LBOpts) of
         {ok, _} = OK ->
             OK;
-        {error, no_proc} ->
+        {error, noproc} ->
             choose(bondy_registry:match(Cont), CallOpts);
         Error ->
             Error
@@ -1694,7 +1694,7 @@ choose([H|T], CallOpts, LastGroup, Acc, Cont) ->
             case bondy_rpc_load_balancer:select(L, LBOpts) of
                 {ok, _} = OK ->
                     OK;
-                {error, no_proc} ->
+                {error, noproc} ->
                     %% We continue w/next group, we reset Acc
                     choose(T, CallOpts, Group, [H], Cont);
                 Error ->

--- a/apps/bondy/src/bondy_http_gateway_rest_handler.erl
+++ b/apps/bondy/src/bondy_http_gateway_rest_handler.erl
@@ -924,6 +924,7 @@ wamp_context(RealmUri, Peer, St1) ->
         peer => Peer,
         is_anonymous => IsAnonymous,
         authid => Authid,
+        authroles => authroles(St1),
         roles => #{
             caller => #{
                 features => #{
@@ -948,6 +949,14 @@ authid(#{is_anonymous := true}) ->
 
 authid(St) ->
     maps:get(authid, St).
+
+
+%% @private
+authroles(#{api_context := #{<<"security">> := #{<<"groups">> := Groups}}}) ->
+   Groups;
+
+authroles(_) ->
+    [].
 
 
 %% @private

--- a/apps/bondy/src/bondy_oauth2.erl
+++ b/apps/bondy/src/bondy_oauth2.erl
@@ -267,6 +267,9 @@ revoke_token(refresh_token, RealmUri, Issuer, Token) ->
     revoke_refresh_token(RealmUri, Issuer, Token);
 
 revoke_token(access_token, _, _, _) ->
+    {error, unsupported_operation};
+
+revoke_token(undefined, _, _, _) ->
     {error, unsupported_operation}.
 
 
@@ -285,6 +288,9 @@ revoke_token(refresh_token, RealmUri, Issuer, Username, DeviceId) ->
     revoke_refresh_token(RealmUri, Issuer, Username, DeviceId);
 
 revoke_token(access_token, _, _, _, _) ->
+    {error, unsupported_operation};
+
+revoke_token(undefined, _, _, _, _) ->
     {error, unsupported_operation}.
 
 


### PR DESCRIPTION
In oauth2 flow, we need the proper authroles in the wamp context. The motivation for this is trying to use the x_disclose_session_info  => true feature, to be able to receive in the wamp INVOCATION.Details the right info.
Current:
```
#{caller => 821480283777806,
  <<"caller_authid">> => <<"...">>,
  <<"caller_authrole">> => <<"undefined">>,
  <<"procedure">> => <<"com.some_procedure">>,
  <<"x_session_info">> =>
      #{<<"authextra">> =>
            #{<<"meta">> => #{<<"description">> => <<"...">>},
              <<"node">> => <<"bondy@127.0.0.1">>,
              <<"session_guid">> => <<"0PoioeMeOkAPW8lTmjrDb9I9lir">>},
        <<"authid">> => <<"...">>,
        <<"authmethod">> => undefined,
        <<"authprovider">> => <<"com.leapsight.bondy">>,
        <<"authrole">> => <<"undefined">>,<<"session">> => 821480283777806,
        <<"transport">> => #{<<"peername">> => <<"192.168.65.1:27065">>},
        <<"x_authroles">> => [],
        <<"x_meta">> => #{<<"description">> => <<"...">>}}}
```
With this changes:
```
#{caller => 3530373104378636,
  <<"caller_authid">> => <<"...">>,
  <<"caller_authrole">> => <<"admin,api_clients">>,
  <<"procedure">> => <<"com.some_procedure">>,
  <<"x_session_info">> =>
      #{<<"authextra">> =>
            #{<<"meta">> => #{<<"description">> => <<"...">>},
              <<"node">> => <<"bondy@127.0.0.1">>,
              <<"session_guid">> => <<"1mxE2XnpoePw7llEZkiDawm4SRQ">>},
        <<"authid">> => <<"...">>,
        <<"authmethod">> => undefined,
        <<"authprovider">> => <<"com.leapsight.bondy">>,
        <<"authrole">> => <<"admin,api_clients">>,
        <<"session">> => 3530373104378636,
        <<"transport">> => #{<<"peername">> => <<"127.0.0.1:53527">>},
        <<"x_authroles">> => [<<"admin">>,<<"api_clients">>],
        <<"x_meta">> => #{<<"description">> => <<"...">>}}}
```