### PR TITLE
Fix checking user credentials changes in on_merge when the old value was previously deleted in plum_db

### DIFF
--- a/apps/bondy/src/bondy_rbac_user.erl
+++ b/apps/bondy/src/bondy_rbac_user.erl
@@ -1314,6 +1314,7 @@ do_update(RealmUri, User, Data, Opts) when is_map(User) ->
 
 
 %% @private
+%% User can't be a TOMBSTONE because is checked before calling this function
 have_credentials_changed(User, Data) when is_list(User) ->
     %% Support for legacy formar
     have_credentials_changed(value_from_term(User), Data);
@@ -1321,6 +1322,10 @@ have_credentials_changed(User, Data) when is_list(User) ->
 have_credentials_changed(User, Data) when is_list(Data) ->
     %% Support for legacy formar
     have_credentials_changed(User, value_from_term(Data));
+
+have_credentials_changed(_, ?TOMBSTONE) ->
+    %% Credentials were deleted
+    true;
 
 have_credentials_changed(User, Data) ->
     has_password_changed(User, Data)


### PR DESCRIPTION
Fix checking user credentials changes in on_merge due to an error with reason={badmap,'$deleted'} when the "Old Value" was previously deleted in plum_db. Below you can find the error:
```json
"2024-06-11T17:51:05.772677202Z stdout F \u001b[1;31mwhen=2024-06-11T17:51:05.772294+00:00 level=error pid=<0.1800.0> at=bondy_jobs_worker:handle_cast/2:204 description=\"Error during async execute\"\u001b[0m reason={badmap,'$deleted'} node=bondy@bondy-1.bondy.message-brokers.svc.cluster.local router_vsn=1.0.0-rc.20 stacktrace=\"[{maps,get,[password,'$deleted',undefined],[{file,\\\"maps.erl\\\"},{line,581},{error_info,#{module => erl_stdlib_errors}}]},{bondy_rbac_user,has_password_changed,2,[{file,\\\"/bondy/src/apps/bondy/src/bondy_rbac_user.erl\\\"},{line,1332}]},{bondy_rbac_user,have_credentials_changed,2,[{file,\\\"/bondy/src/apps/bondy/src/bondy_rbac_user.erl\\\"},{line,1326}]},{bondy_rbac_user,'-on_merge/3-fun-0-',4,[{file,\\\"/bondy/src/apps/bondy/src/bondy_rbac_user.erl\\\"},{line,1136}]},{bondy_jobs_worker,handle_cast,2,[{file,\\\"/bondy/src/apps/bondy/src/bondy_jobs_worker.erl\\\"},{line,201}]},{gen_server,try_dispatch,4,[{file,\\\"gen_server.erl\\\"},{line,1123}]},{gen_server,handle_msg,6,[{file,\\\"gen_server.erl\\\"},{line,1200}]},{proc_lib,init_p_do_apply,3,[{file,\\\"proc_lib.erl\\\"},{line,240}]}]\" "
```