### PR TITLE
Fix checking password length reading them from configuration

### DIFF
--- a/apps/bondy/src/bondy_password.erl
+++ b/apps/bondy/src/bondy_password.erl
@@ -572,8 +572,10 @@ new_scram(Password, Params) ->
 validate_string(Password) ->
     Size = byte_size(Password),
     Regex = persistent_term:get({?MODULE, regex}),
+    Min = bondy_config:get([security, password, min_length]),
+    Max = bondy_config:get([security, password, max_length]),
 
-    Size >= 6 andalso Size =< 256
+    Size >= Min andalso Size =< Max
     andalso nomatch =:= re:run(Password, Regex)
     orelse error(invalid_password),
 

--- a/schema/bondy.schema
+++ b/schema/bondy.schema
@@ -176,7 +176,7 @@
 
 %% -----------------------------------------------------------------------------
 %% @doc Defines the minimum length for newly created passwords. The value
-%% should be at least 6 and at most 254.
+%% should be at least 3 and at most 256.
 %% @end
 %% -----------------------------------------------------------------------------
 {mapping, "security.password.min_length", "bondy.security.password.min_length", [
@@ -188,11 +188,11 @@
 {translation, "bondy.security.password.min_length",
   fun(Conf) ->
     case cuttlefish:conf_get("security.password.min_length", Conf) of
-        Value when is_integer(Value), Value >= 6, Value =< 254 ->
+        Value when is_integer(Value), Value >= 3, Value =< 256 ->
           Value;
         _ ->
             cuttlefish:invalid(
-              "value should be an integer in the range 6..254"
+              "value should be an integer in the range 3..256"
             )
     end
   end
@@ -200,7 +200,7 @@
 
 %% -----------------------------------------------------------------------------
 %% @doc Defines the maximum length for newly created passwords. The value
-%% should be at least 6 and at most 254.
+%% should be at least 3 and at most 256.
 %% @end
 %% -----------------------------------------------------------------------------
 
@@ -213,11 +213,11 @@
   fun(Conf) ->
     Min = cuttlefish:conf_get("security.password.min_length", Conf),
     case cuttlefish:conf_get("security.password.max_length", Conf) of
-        Value when is_integer(Value), Value >= Min, Value =< 254 ->
+        Value when is_integer(Value), Value >= Min, Value =< 256 ->
           Value;
         _ ->
             cuttlefish:invalid(
-              "value should be an integer in the range {Min}..254"
+              "value should be an integer in the range {Min}..256"
             )
     end
   end


### PR DESCRIPTION
Fix checking password length (min & max) reading them from configuration. The minimum value was changed to 3 instead of 6 for compatibility with old deployments. The maximum value was changed to 256 instead of 254.