### PR TITLE
Adding the option to be able to delete an public http api spec

### DIFF
--- a/apps/bondy/priv/specs/bondy_admin_api.json
+++ b/apps/bondy/priv/specs/bondy_admin_api.json
@@ -310,6 +310,24 @@
                                 "body" : "{{action.result.args |> head}}"
                             }
                         }
+                    },
+                    "delete" : {
+                        "action" : {
+                            "type" : "wamp_call",
+                            "procedure" : "bondy.http_gateway.api.delete",
+                            "options" : {},
+                            "args" : ["{{request.bindings.id}}"],
+                            "kwargs" : {}
+                        },
+                        "response" : {
+                           "on_error" : {
+                               "status_code" : "{{status_codes |> get({{action.error.error_uri}}, 500) |> integer}}",
+                                "body" : "{{variables.wamp_error_body}}"
+                            },
+                            "on_result" : {
+                                "body" : "{{action.result.args |> head}}"
+                            }
+                        }
                     }
                 },
                 "/api_specs/:id/info" : {

--- a/apps/bondy/src/bondy_http_gateway.erl
+++ b/apps/bondy/src/bondy_http_gateway.erl
@@ -885,10 +885,20 @@ rebuild_dispatch_table(https, Routes) ->
     rebuild_dispatch_table(<<"https">>, Routes);
 
 rebuild_dispatch_table(<<"http">>, Routes) ->
-    cowboy:set_env(?HTTP, dispatch, cowboy_router:compile(Routes));
-
+    case bondy_config:get([?HTTP, enabled], true) of
+        true ->
+            cowboy:set_env(?HTTP, dispatch, cowboy_router:compile(Routes));
+        false ->
+            ok
+    end;
+    
 rebuild_dispatch_table(<<"https">>, Routes) ->
-    cowboy:set_env(?HTTPS, dispatch, cowboy_router:compile(Routes)).
+    case bondy_config:get([?HTTPS, enabled], true) of
+        true ->
+            cowboy:set_env(?HTTPS, dispatch, cowboy_router:compile(Routes));
+        false ->
+            ok
+    end.
 
 
 %% @private

--- a/apps/bondy/src/bondy_http_gateway_wamp_api.erl
+++ b/apps/bondy/src/bondy_http_gateway_wamp_api.erl
@@ -85,6 +85,18 @@ handle_call(?BONDY_HTTP_GATEWAY_GET, #call{} = M, Ctxt) ->
             {reply, R}
     end;
 
+handle_call(?BONDY_HTTP_GATEWAY_DELETE, #call{} = M, Ctxt) ->
+    [Id] = bondy_wamp_utils:validate_admin_call_args(M, Ctxt, 1),
+
+    case bondy_http_gateway:delete(Id) of
+        {error, Reason} ->
+            E = bondy_wamp_utils:error(Reason, M),
+            {reply, E};
+        Spec ->
+            R = wamp_message:result(M#call.request_id, #{}, [Spec]),
+            {reply, R}
+    end;
+
 handle_call(_, #call{} = M, _) ->
     E = bondy_wamp_utils:no_such_procedure_error(M),
     {reply, E}.


### PR DESCRIPTION
Adding the option to be able to delete an public http api spec using the 'bondy.http_gateway.api.delete' procedure