### PR TITLE
Fix an error removing group from a realm

### DIFF
--- a/apps/bondy/src/bondy_rbac_group.erl
+++ b/apps/bondy/src/bondy_rbac_group.erl
@@ -827,6 +827,8 @@ type_and_version(Group) ->
 
 update_groups(RealmUri, all, Groupnames, Fun) ->
     plum_db:foreach(fun
+        ({_, ?TOMBSTONE}) ->
+            ok;
         ({_, [?TOMBSTONE]}) ->
             ok;
         ({_, _} = Term) ->


### PR DESCRIPTION
To fix the following error:
```erlang
when=2024-07-25T13:08:17.574137+00:00 level=warning pid=<0.5928.0> at=bondy_dealer:apply_static_callback/3:1029 description="Error while handling WAMP call" reason=function_clause node=bondy1@127.0.0.1 router_vsn=1.0.0-rc.22 realm=com.leapsight.bondy agent=undefined authmethod=wampcra session_id=1R4eZLxbaXdcoDdmjm8J7A9RYmd protocol_session_id=2834189352713953 protocol=wamp transport=websockets peername=192.168.65.1:42798 serializer=json source_ip=192.168.65.1 procedure=bondy.group.delete class=error stacktrace="[{bondy_rbac_group,from_term,[{<<\"1\">>,'$deleted'}],[{file,\"/bondy/src/apps/bondy/src/bondy_rbac_group.erl\"},{line,800}]},{bondy_rbac_group,'-update_groups/4-fun-0-',4,[{file,\"/bondy/src/apps/bondy/src/bondy_rbac_group.erl\"},{line,833}]},{plum_db,do_foreach,3,[{file,\"/bondy/src/_build/default/lib/plum_db/src/plum_db.erl\"},{line,705}]},{plum_db,foreach,3,[{file,\"/bondy/src/_build/default/lib/plum_db/src/plum_db.erl\"},{line,675}]},{bondy_rbac_group,remove,3,[{file,\"/bondy/src/apps/bondy/src/bondy_rbac_group.erl\"},{line,390}]},{bondy_rbac_group_wamp_api,handle_call,3,[{file,\"/bondy/src/apps/bondy/src/bondy_rbac_group_wamp_api.erl\"},{line,69}]},{bondy_dealer,apply_static_callback,3,[{file,\"/bondy/src/apps/bondy/src/bondy_dealer.erl\"},{line,1000}]},{bondy_dealer,forward,2,[{file,\"/bondy/src/apps/bondy/src/bondy_dealer.erl\"},{line,601}]}]" caller="{bondy_ref,client,<<\"bondy1@127.0.0.1\">>,<<\"1R4eZLxbaXdcoDdmjm8J7A9RYmd\">>,{pid,<<\"<0.5454.0>\">>}}"
```