### PR TITLE
Fixes but with questions related to some errors collected from one deployment

### DIFF
--- a/apps/bondy/src/bondy_password.erl
+++ b/apps/bondy/src/bondy_password.erl
@@ -399,6 +399,11 @@ verify_string(String, #{version := <<"1.0">>} = PW) ->
     %% StoredHash is hex value
     pbkdf2:compare_secure(pbkdf2:to_hex(Hash), StoredHash);
 
+%% to handle the error: reason=function_clause
+%% example: [{bondy_password,verify_string,[<<\"Nes 2907\">>,[{hash_pass,<<\"adcebee9a2cbbe4e26c340f95da646a1ab60c676\">>},{auth_name,pbkdf2},{hash_func,sha},{salt,<<76,202,0,27,196,167,217,222,194,142,96,185,219,169,96,233>>},{iterations,65536}]]
+verify_string(Hash, PWList) when is_list(PWList) ->
+    verify_string(Hash, maps:from_list(PWList));
+
 verify_string(Hash, #{} = PW) ->
     verify_string(Hash, add_version(PW)).
 

--- a/apps/bondy/src/bondy_registry.erl
+++ b/apps/bondy/src/bondy_registry.erl
@@ -1989,6 +1989,7 @@ do_prune(_Node, _Index, _From, L) when is_list(L) ->
                     ok;
 
                 ?TOMBSTONE ->
+                    %% it is not a possible result; TODO: delete it!
                     ok;
 
                 Entry ->

--- a/apps/bondy/src/bondy_registry_entry.erl
+++ b/apps/bondy/src/bondy_registry_entry.erl
@@ -979,12 +979,39 @@ dirty_delete(Type, EntryKey) ->
 
     case plum_db:get_object({PDBPrefix, EntryKey}) of
         undefined ->
+            %% It is possible?
             undefined;
 
         ?TOMBSTONE ->
+            %% It is possible?
+            %% or [{?TOMBSTONE, _}] = plum_db_dvvset:values(Clock),
             undefined;
 
-        {object, Clock} = Obj0 ->
+        {error, Reason} ->
+            %% It is possible?
+            undefined;
+
+        % {{case_clause,{ok,{object,{[{{10,\
+        % 'bondy@bondy-2.bondy.message-brokers.svc.cluster.local'},\
+        % 2,\
+        % [{'$deleted',{1723,148981,370249}}]}],\
+        % []}}}},\
+        % [{bondy_registry_entry,dirty_delete,2,\
+        % [{file,\"/bondy/src/apps/bondy/src/bondy_registry_entry.erl\"},\
+        % {line,980}]},\
+        % {bondy_registry,'-do_prune/4-fun-0-',1,\
+        % [{file,\"/bondy/src/apps/bondy/src/bondy_registry.erl\"},\
+        % {line,1980}]},\
+        % {lists,foreach_1,2,[{file,\"lists.erl\"},{line,1686}]},\
+        % {bondy_registry,do_prune,3,\
+        % [{file,\"/bondy/src/apps/bondy/src/bondy_registry.erl\"},\
+        % {line,1966}]}]}\
+
+        % Clock = {[{{10,'bondy@bondy-2.bondy.message-brokers.svc.cluster.local'},2,[{'$deleted',{1723,148981,370249}}]}],[]}.
+        % plum_db_dvvset:values(Clock).
+        % [{'$deleted',{1723,148981,370249}}]
+
+        {ok, {object, Clock} = Obj0} ->
             %% We use a static fake ActorID and the original timestamp so that
             %% the tombstone is deterministically.
             %% This allows the operation to be idempotent when performed


### PR DESCRIPTION
Fixes but with questions related to some errors collected from one deployment with the latest version 1.0.0-rc.22:
- verifying password when we are trying to change the password
```erlang
2024-08-13T09:14:59.866952595Z stdout F [1;33mwhen=2024-08-13T09:14:59.866454+00:00 level=warning pid=<0.7579.0> at=bondy_dealer:apply_static_callback/3:1029 description="Error while handling WAMP call"[0m reason=function_clause node=bondy@bondy-0.bondy.message-brokers.svc.cluster.local router_vsn=1.0.0-rc.22 realm=com.magenta.public agent=accounts_service-0.56.5 authmethod=anonymous session_id=27cR6drUnV0zreMV5OjxbUH56Pl protocol_session_id=4187881905737063 protocol=wamp transport=ranch_tcp peername=10.13.17.192:44471 listener=wamp_tcp serializer=json stacktrace="[{bondy_password,verify_string,[<<\"CHICHO1967\">>,[{hash_pass,<<\"b2e38270ae24d4ee50aa17de138286d1c17d668e\">>},{auth_name,pbkdf2},{hash_func,sha},{salt,<<52,12,218,80,29,58,229,166,24,204,65,148,39,215,198,189>>},{iterations,65536}]],[{file,\"/bondy/src/apps/bondy/src/bondy_password.erl\"},{line,358}]},{bondy_rbac_user,do_change_password,4,[{file,\"/bondy/src/apps/bondy/src/bondy_rbac_user.erl\"},{line,1374}]},{bondy_rbac_user_wamp_api,handle_call,3,[{file,\"/bondy/src/apps/bondy/src/bondy_rbac_user_wamp_api.erl\"},{line,132}]},{bondy_dealer,apply_static_callback,3,[{file,\"/bondy/src/apps/bondy/src/bondy_dealer.erl\"},{line,1000}]},{bondy_dealer,forward,2,[{file,\"/bondy/src/apps/bondy/src/bondy_dealer.erl\"},{line,601}]},{bondy_router,forward,2,[{file,\"/bondy/src/apps/bondy/src/bondy_router.erl\"},{line,182}]},{bondy_wamp_protocol,handle_inbound_messages,3,[{file,\"/bondy/src/apps/bondy/src/bondy_wamp_protocol.erl\"},{line,543}]},{bondy_wamp_protocol,handle_inbound_messages,2,[{file,\"/bondy/src/apps/bondy/src/bondy_wamp_protocol.erl\"},{line,385}]}]" source_ip=10.13.17.192 procedure=com.leapsight.bondy.security.change_password class=error caller="{bondy_ref,client,<<\"bondy@bondy-0.bondy.message-brokers.svc.cluster.local\">>,<<\"27cR6drUnV0zreMV5OjxbUH56Pl\">>,{pid,<<\"<0.7579.0>\">>}}"
```
- removing "deleted" entries in the registration trie and/or store
```erlang
when=2024-08-13T12:39:24.010991+00:00 level=error pid=<0.25612072.0> at=: node=bondy@bondy-0.bondy.message-brokers.svc.cluster.local router_vsn=1.0.0-rc.22 unstructured_log="Error in process <0.25612072.0> on node 'bondy@bondy-0.bondy.message-brokers.svc.cluster.local' with exit value:\
2024-08-13T12:39:24.011447311Z {{case_clause,{ok,{object,{[{{10,\
2024-08-13T12:39:24.011451017Z                               'bondy@bondy-2.bondy.message-brokers.svc.cluster.local'},\
2024-08-13T12:39:24.011453891Z                              2,\
2024-08-13T12:39:24.011456453Z                              [{'$deleted',{1723,148981,370249}}]}],\
2024-08-13T12:39:24.011458909Z                            []}}}},\
2024-08-13T12:39:24.011461504Z  [{bondy_registry_entry,dirty_delete,2,\
2024-08-13T12:39:24.011464132Z                         [{file,\"/bondy/src/apps/bondy/src/bondy_registry_entry.erl\"},\
2024-08-13T12:39:24.011466212Z                          {line,980}]},\
2024-08-13T12:39:24.011468237Z   {bondy_registry,'-do_prune/4-fun-0-',1,\
2024-08-13T12:39:24.011470448Z                   [{file,\"/bondy/src/apps/bondy/src/bondy_registry.erl\"},\
2024-08-13T12:39:24.011473757Z                    {line,1980}]},\
2024-08-13T12:39:24.011476122Z   {lists,foreach_1,2,[{file,\"lists.erl\"},{line,1686}]},\
2024-08-13T12:39:24.011478368Z   {bondy_registry,do_prune,3,\
2024-08-13T12:39:24.011480653Z                   [{file,\"/bondy/src/apps/bondy/src/bondy_registry.erl\"},\
2024-08-13T12:39:24.011482822Z                    {line,1966}]}]}\
2024-08-13T12:39:24.011484870Z " error_logger_tag=error error_logger_emulator=true 
when=2024-08-13T12:39:29.011350+00:00 level=info pid=<0.1704.0> at=partisan_pluggable_peer_service_manager:handle_message/4:1793 description="Shutting down: membership doesn't contain us" reason="We've been removed from the cluster." node=bondy@bondy-0.bondy.message-brokers.svc.cluster.local router_vsn=1.0.0-rc.22 
when=2024-08-13T12:39:29.011840+00:00 level=error pid=<0.1703.0> at=supervisor:do_restart/3:744 node=bondy@bondy-0.bondy.message-brokers.svc.cluster.local router_vsn=1.0.0-rc.22 logger_formatter_title="SUPERVISOR REPORT" report_errorContext=child_terminated report_supervisor={local,partisan_peer_service_sup} report_offender_mfargs={partisan_pluggable_peer_service_manager,start_link,[]} report_offender_restart_type=permanent report_offender_child_type=worker report_offender_significant=false report_offender_shutdown=5000 report_offender_pid=<0.1704.0> report_offender_id=partisan_pluggable_peer_service_manager report_reason=normal domain=[otp,sasl] label={supervisor,child_terminated} error_logger_report_cb="fun supervisor:format_log/1" error_logger_type=supervisor_report error_logger_tag=error_report 
when=2024-08-13T12:39:29.012371+00:00 level=info pid=<0.25612110.0> at=partisan_peer_discovery_agent:init/1:186 description="Peer discovery agent will start after initial delay" node=bondy@bondy-0.bondy.message-brokers.svc.cluster.local router_vsn=1.0.0-rc.22 delay_msecs=30000 
```