### PR TITLE
Fix when the stored password in version 1.0 is verified 

### DIFF
--- a/apps/bondy/src/bondy_password.erl
+++ b/apps/bondy/src/bondy_password.erl
@@ -340,7 +340,8 @@ verify_hash(Hash, #{version := <<"1.1">>} = PW) ->
 
 verify_hash(Hash, #{version := <<"1.0">>} = PW) when is_binary(Hash) ->
     #{hash_pass := Salted} = PW,
-    crypto:hash_equals(Hash, Salted);
+    %% in version 1.0 the stored hash is hex encoded
+    crypto:hash_equals(Hash, hex_utils:hexstr_to_bin(Salted));
 
 verify_hash(Hash, #{} = PW) ->
     verify_string(Hash, add_version(PW)).
@@ -379,10 +380,10 @@ verify_string(String, #{version := <<"1.1">>} = PW) ->
     HashLen = hash_length(PW),
 
     %% We use keylen in version > 1.0
-    Hash0 = crypto:pbkdf2_hmac(HashFun, String, Salt, HashIter, HashLen),
+    Hash = crypto:pbkdf2_hmac(HashFun, String, Salt, HashIter, HashLen),
 
     %% Stored Salted is base64 encoded in 1.1
-    crypto:hash_equals(Salted, base64:encode(Hash0));
+    crypto:hash_equals(Salted, base64:encode(Hash));
 
 verify_string(String, #{version := <<"1.0">>} = PW) ->
     #{
@@ -393,7 +394,8 @@ verify_string(String, #{version := <<"1.0">>} = PW) ->
     } = PW,
     HashLen = hash_length(PW),
     Hash = crypto:pbkdf2_hmac(HashFun, String, Salt, HashIter, HashLen),
-    crypto:hash_equals(Hash, Salted);
+    %% in version 1.0 the stored hash is hex encoded
+    crypto:hash_equals(Hash, hex_utils:hexstr_to_bin(Salted));
 
 %% to handle the error: reason=function_clause
 %% example: [{bondy_password,verify_string,[<<\"Nes 2907\">>,[{hash_pass,<<\"adcebee9a2cbbe4e26c340f95da646a1ab60c676\">>},{auth_name,pbkdf2},{hash_func,sha},{salt,<<76,202,0,27,196,167,217,222,194,142,96,185,219,169,96,233>>},{iterations,65536}]]


### PR DESCRIPTION
Fix when the stored password in version 1.0 is verified due to the salted is store encoded in hex. The fixed error is due to the byte_size of the compared hashes were different and we had the failure (example below):
```erlang
exception_from {bondy_password,verify_string,2} {error,badarg}
** exception error: bad argument
     in function  crypto:hash_equals_nif/2
        called as crypto:hash_equals_nif(<<254,76,219,15,117,107,76,4,142,25,228,42,58,32,145,204,
                                           31,208,213,153>>,
                                         <<"f8b1bdd6cb24f1966c44c961f4b629b3e8b120d2">>)
```