### PR TITLE
RBAC backward compatibility

### DIFF
--- a/apps/bondy/src/bondy_rbac.erl
+++ b/apps/bondy/src/bondy_rbac.erl
@@ -547,7 +547,10 @@ revoke(RealmUri, #{type := request} = Request) ->
     } = Request,
     revoke(RealmUri, Roles, Resources, Permissions);
 
-revoke(RealmUri, Data) when is_map(Data) ->
+revoke(RealmUri, Data0)  when is_map(Data0) ->
+    Uri = maps:get(~"uri", Data0, any),
+    Match = maps:get(~"match", Data0, ?PREFIX_MATCH),
+    Data = Data0#{~"uri" => Uri, ~"match" => Match},
     revoke(RealmUri, validate(Data)).
 
 
@@ -706,6 +709,9 @@ externalize_grant({{Role, {_, _} = Resource}, Permissions}) ->
 %% -----------------------------------------------------------------------------
 externalize_grant({{<<>>, Strategy}, Permissions}) ->
     externalize_grant({{any, Strategy}, Permissions});
+
+externalize_grant({{<<"group/", _/binary>> = Role, Strategy}, Permissions}) ->
+    externalize_grant({{Role, { <<>>, Strategy}}, Permissions});
 
 externalize_grant({{Uri, Strategy}, Permissions}) ->
     #{

--- a/apps/bondy/src/bondy_rbac_source.erl
+++ b/apps/bondy/src/bondy_rbac_source.erl
@@ -415,7 +415,15 @@ to_external(#{type := source, version := ?VERSION} = Source) ->
     String = iolist_to_binary(
         io_lib:format("~s/~B", [inet_parse:ntoa(Addr), Mask])
     ),
-    maps:put(cidr, String, Source).
+    maps:put(cidr, String, Source);
+to_external({_, #{type := source, version := ?VERSION} = Source}) ->
+    {Addr, Mask} = maps:get(cidr, Source),
+    String = iolist_to_binary(
+        io_lib:format("~s/~B", [inet_parse:ntoa(Addr), Mask])
+    ),
+    maps:put(cidr, String, Source);
+to_external(InvalidSource) ->
+    throw({error, {invalid_source, InvalidSource}}).
 
 
 


### PR DESCRIPTION
This pull request introduces improvements to the handling and externalization of RBAC (Role-Based Access Control) data in the Bondy application. The main changes enhance the robustness and flexibility of RBAC operations, especially in processing input data and handling group roles.

**RBAC Data Handling Improvements:**

* Updated the `revoke/2` function in `bondy_rbac.erl` to ensure that the `uri` and `match` keys are always present in the data map, providing default values if missing. This improves the function's robustness when handling incomplete input data.

* Enhanced the `externalize_grant/1` function in `bondy_rbac.erl` to handle group roles (roles starting with `"group/"`) by normalizing them to a consistent internal structure before externalization.

**RBAC Source Externalization Enhancements:**

* Improved the `to_external/1` function in `bondy_rbac_source.erl` to support both map and tuple input formats, and to throw a clear error on invalid input. This ensures more reliable and predictable externalization of RBAC source data.