### PR TITLE
fix: decode partial JSON for ERROR messages in message_to_map/1

### DIFF
--- a/apps/bondy/src/bondy.erl
+++ b/apps/bondy/src/bondy.erl
@@ -661,7 +661,10 @@ message_to_map(#result{} = M0) ->
         kwargs => kwargs(KWArgs)
     };
 
-message_to_map(#error{} = M) ->
+message_to_map(#error{} = M0) ->
+
+    M = bondy_wamp_message:decode_partial(M0),
+
     #error{
         request_type = Type,
         request_id = Id,


### PR DESCRIPTION
### Problem

In Bondy rc64, WAMP ERROR messages returned by remote callees (e.g., Java via Vert.x WAMP) lose their `args` and `kwargs` when processed by the API Gateway.

This causes fields like `message`, `description`, and `keys` in HTTP error responses (defined via `on_error` templates in `api_spec.json`) to be empty, regardless of how the template is configured.

### Root Cause

Commit `84eb1062` migrated the WAMP library from an external dependency (`wamp` tag `1.0.0`) to an internal umbrella app (`bondy_wamp`). This introduced **partial JSON decoding** (`maybe_partial_json_decode/2` in `bondy_wamp_encoding.erl:889`) as an optimization: when a WAMP message carries `args`/`kwargs`, the parser splits them:

- **Head:** the core message body (e.g., `[8, RequestType, RequestId, Details, ErrorUri]`)
- **Tail:** `args` and `kwargs` stored as raw binary in the `#error.partial` field

In `bondy.erl`, the `message_to_map/1` function converts WAMP messages to maps for the MOPS template context used by the API Gateway. The `#result{}` clause was already updated to call `decode_partial/1` (line 649), restoring `args`/`kwargs` from the `partial` field. However, the `#error{}` clause (line 664) **was not updated**, so `args` and `kwargs` remained `undefined`.

### Solution

Added `M = bondy_wamp_message:decode_partial(M0),` to the `#error{}` clause in `message_to_map/1`, mirroring the existing `#result{}` clause:

```erlang
message_to_map(#error{} = M0) ->

    M = bondy_wamp_message:decode_partial(M0),

    #error{
        ...
    } = M,
```
### Impact
- API Gateway: on_error templates in api_spec.json now correctly receive {{action.error.args}} and {{action.error.kwargs}} when a callee returns a WAMP ERROR.
- No breaking change: decode_partial/1 is idempotent for messages that are already fully decoded (the partial field is undefined in those cases).
- Symmetrical: The fix replicates the exact pattern already in place for #result{}, minimizing the change surface (2 effective lines).