### PR TITLE
rbac: reconcile group membership on declarative user store

### DIFF
--- a/apps/bondy_router/src/bondy_rbac_user.erl
+++ b/apps/bondy_router/src/bondy_rbac_user.erl
@@ -1785,9 +1785,10 @@ update_groups(RealmUri, Username, Groupnames, Fun) when is_binary(Username) ->
 %% `groups` is NOT persisted in the user cell — membership is the authoritative
 %% cell-per-fact `security_group_members` relation. The persisted value is the
 %% user map with `groups` stripped; the desired membership set (the map's
-%% `groups`) is reconciled into the relation. The user-cell write still happens
-%% on every membership change, so its HLC — the `token_version` — keeps
-%% advancing (a removed/added group forces the zookie forward, design §9.3).
+%% `groups`) is reconciled into the relation on every store, declarative or not.
+%% The user-cell write still happens on every membership change, so its HLC —
+%% the `token_version` — keeps advancing (a removed/added group forces the
+%% zookie forward, design §9.3).
 store(RealmUri, #{username := Username} = User, #{declarative := true}) ->
     %% Declarative config apply: write WITHOUT firing the runtime lifecycle
     %% side-effects, and IDEMPOTENTLY — emit a write only when the stored value
@@ -1796,9 +1797,13 @@ store(RealmUri, #{username := Username} = User, #{declarative := true}) ->
     %% digest); the op-based CRDT + anti-entropy handle convergence, so no
     %% deterministic-version rebase is needed. The user object is deterministic
     %% (see `bondy_realm:validate_rbac_config` for the deterministic salt), so an
-    %% unchanged config compares equal. Membership replicates via its own
-    %% relation cells, so this does NOT reconcile group membership.
+    %% unchanged config compares equal. The membership relation gets the same
+    %% idempotent treatment as grants/sources (`bondy_rbac:store/5`,
+    %% `bondy_rbac_source:store/5`): `reconcile_membership/3` diffs desired vs.
+    %% current and only asserts/retracts the delta, so a converged boot (or a
+    %% node that already has the fact via anti-entropy) performs zero writes.
     Desired = strip_groups(User),
+    ok = reconcile_membership(RealmUri, Username, maps:get(groups, User, [])),
     case do_get(RealmUri, Username) of
         Desired ->
             %% Unchanged — no write, no new operation, convergence undisturbed.

--- a/apps/bondy_router/src/bondy_realm.erl
+++ b/apps/bondy_router/src/bondy_realm.erl
@@ -1590,7 +1590,7 @@ from_file(Filename, Opts) ->
                         Prefix = binary_utils:join([A, B, C], <<", ">>),
                         <<Prefix/binary, "...">>;
                     false ->
-                        binary_utils:join([<<"a">>, <<"b">>], <<", ">>)
+                        binary_utils:join(Uris, <<", ">>)
                 end,
 
             ?LOG_INFO(#{


### PR DESCRIPTION
Every user provisioned via a realm's security_config.json (loaded through bondy_realm:apply_config/0 -> from_file/2 with `#{declarative => true}`) ends up with an empty group list, even though the config's per-user `"groups"` field is present and the referenced groups exist with correct grants. Any wamp.call/register/publish/subscribe the user should be authorized for via those groups is denied with `wamp.error.not_authorized`, because bondy_rbac:get_context/2 resolves an empty grant set for a user with no group memberships.

**Root cause**: bondy_rbac_user:store/3 has two clauses. The `#{declarative := true}` clause (the one every config-file bootstrap goes through) only ever writes the user's own cell; it does not call reconcile_membership/3, so the `security_group_members` relation is never populated. The non-declarative clause (used by the runtime add/update API path) does call it. This is why calling bondy_rbac_user:add_group/3 directly against a running node "fixes" an affected user: that helper goes through the non-declarative store clause.

This is an omission, not a deliberate trade-off: the two other declaratively-applied many-to-many relations in this same module set
  - grants (bondy_rbac:store/5) and sources (bondy_rbac_source:store/5)
  - both still write their relation under declarative apply, just via bondy_db:reconcile/4 instead of bondy_db:apply/4, to get an idempotent write instead of skipping it. Group membership had no equivalent path at all.

**Fix**: call reconcile_membership/3 unconditionally in both store/3 clauses. reconcile_membership/3 is already diff-based - it reads the current membership set and only asserts/retracts the delta against desired - so on a node that already converged (either from a prior local write or via anti-entropy from a peer) this is a single bounded forward-band scan with zero writes. Same idempotency guarantee as the grants/sources paths, now applied consistently to membership.

Also fixes bondy_realm:from_file/2's boot log: the `summary` field logged for a config file with <=3 realms was a hardcoded `binary_utils:join([<<"a">>, <<"b">>], <<", ">>)` placeholder instead of the actual realm URIs, unrelated to the fix above but noticed while diagnosing this issue via the boot logs.