### PR TITLE
fix: rewrap outbound iodata before buffering in bondy_http_transport_session

### DIFF
--- a/apps/bondy_router/src/bondy_http_transport_session.erl
+++ b/apps/bondy_router/src/bondy_http_transport_session.erl
@@ -553,19 +553,19 @@ handle_info({?BONDY_REQ, _Pid, _RealmUri, M}, State) ->
     try bondy_wamp_protocol:handle_outbound(M, ProtoState) of
         {ok, Bin, NewProtoState} ->
             S1 = State#state{protocol_state = NewProtoState},
-            S2 = forward_or_buffer(Bin, S1),
+            S2 = forward_or_buffer([Bin], S1),
             {noreply, S2};
         {stop, NewProtoState} ->
             S1 = State#state{protocol_state = NewProtoState},
             {stop, normal, S1};
         {stop, Bin, NewProtoState} ->
             S1 = State#state{protocol_state = NewProtoState},
-            _ = forward_or_buffer(Bin, S1),
+            _ = forward_or_buffer([Bin], S1),
             signal_sse_stop([Bin], S1),
             {stop, normal, S1};
         {stop, Bin, NewProtoState, _After} ->
             S1 = State#state{protocol_state = NewProtoState},
-            _ = forward_or_buffer(Bin, S1),
+            _ = forward_or_buffer([Bin], S1),
             signal_sse_stop([Bin], S1),
             {stop, normal, S1};
         {error, _Reason, NewProtoState} ->


### PR DESCRIPTION
handle_outbound/2 returns a single iodata Bin (not a list), but the three handle_info({?BONDY_REQ, ...}) clauses passed it straight into forward_or_buffer/2, which since e93d986a expects a list. When no SSE stream or long-poll caller was attached, forward_or_buffer's buffering clause called lists:reverse/1 on the raw binary and crashed with function_clause, killing the transport session process and any concurrent auth_claims call against it. Wrap Bin in a list at all three call sites, matching the existing signal_sse_stop([Bin], S1) calls right below them.